### PR TITLE
Log uplink events with status

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -27,7 +27,8 @@ typedef struct {
 
 // Log blob container for q_log
 typedef struct {
-  size_t len;
+  uint8_t status;  // 1 if sent over mesh, 0 if only logged
+  size_t  len;
   uint8_t data[256];
 } log_blob_t;
 

--- a/src/tasks/Task_Logger.cpp
+++ b/src/tasks/Task_Logger.cpp
@@ -99,7 +99,9 @@ void Task_Logger(void *pvParameters) {
       }
 
       uint32_t offset = dataFile.size();
+      uint8_t status = blob.status;
       uint16_t len = blob.len;
+      dataFile.write(&status, sizeof(status));
       dataFile.write((uint8_t *)&len, sizeof(len));
       dataFile.write(blob.data, len);
       dataFile.flush();

--- a/src/tasks/Task_Uplink.cpp
+++ b/src/tasks/Task_Uplink.cpp
@@ -28,8 +28,9 @@ void Task_Uplink(void *pvParameters) {
         }
       }
 
-      if (!sent && q_log) {
+      if (q_log) {
         log_blob_t blob;
+        blob.status = sent ? 1 : 0;
         blob.len = len > sizeof(blob.data) ? sizeof(blob.data) : len;
         memcpy(blob.data, payload, blob.len);
         xQueueSend(q_log, &blob, 0);


### PR DESCRIPTION
## Summary
- Always enqueue uplink events for logging, tagging each with a sent/unsent status.
- Record status in log blobs and persist it to log files for later differentiation.

## Testing
- `g++ -std=c++17 tests/integration_test.cpp -Isrc -o /tmp/integration_test && /tmp/integration_test` *(fails: freertos/FreeRTOS.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8392b64832c88fdd0e7ef129c71