### PR TITLE
Fix queue default initialization

### DIFF
--- a/src/freertos/queue.h
+++ b/src/freertos/queue.h
@@ -13,7 +13,7 @@ typedef struct {
 typedef Queue* QueueHandle_t;
 
 static inline QueueHandle_t xQueueCreate(UBaseType_t length, UBaseType_t item_size) {
-    Queue* q = new Queue{(size_t)item_size, (size_t)length, {}};
+    Queue* q = new Queue{(size_t)item_size, (size_t)length};
     return q;
 }
 


### PR DESCRIPTION
## Summary
- construct the FreeRTOS queue without explicitly value-initializing the std::queue member

## Testing
- g++ -std=c++17 tests/integration_test.cpp -Isrc -o /tmp/integration_test

------
https://chatgpt.com/codex/tasks/task_e_68c86381f644832c8b50b1490eff4cde