### PR TITLE
Update Air530 GPS hardware test results

### DIFF
--- a/docs/hardware_component_tests.md
+++ b/docs/hardware_component_tests.md
@@ -112,7 +112,7 @@ main
 
 | Date | Firmware Commit | Observed Behavior |
 | --- | --- | --- |
-| _pending_ | | |
+| 2025-09-17 | 60ec05e | Indoors the receiver never obtained a fix; after moving outdoors it locked a valid 3D solution with HDOP 0.9 and reported ~8 m altitude. |
 
 ## Grove Vision AI V2 (I²C)
 


### PR DESCRIPTION
## Summary
- document the September 17, 2025 Air530 GPS hardware test including firmware commit 60ec05e

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cb10997a9c832c942bb9dfaf4aac4c